### PR TITLE
Add USB driver installation instructions and ESP32 pinout reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project is a SwitchBot system that allows you to control a physical switch 
 - [Requirements](#requirements)
 - [System Overview](#system-overview)
 - [ESP32 Setup](#esp32-setup)
+- [ESP32 Pinout Reference](#esp32-pinout-reference)
 - [iPhone Application](#iphone-application)
 - [Device Configuration](#device-configuration)
 
@@ -73,6 +74,10 @@ To transfer MicroPython scripts to the ESP32, you can use the `ampy` tool. Follo
    ampy --port /dev/ttyUSB0 put main.py
    ```
    Replace `/dev/ttyUSB0` with the appropriate serial port for your system.
+
+## ESP32 Pinout Reference
+
+For a complete guide to the ESP32 pinout, refer to this [link](https://ciksiti.com/ja/chapters/13091-esp32-pinout-reference--a-complete-guide).
 
 ## iPhone Application
 


### PR DESCRIPTION
Include detailed instructions for installing the USB driver for ESP32 and add a section for transferring files using `ampy`. Also, provide a reference for the ESP32 pinout.